### PR TITLE
Fix deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ $ npm install -g firebase-tools
 
 #### Build and deploy the app:
 ```shell
+$ cd functions
+$ npm install
+$ cd ..
 $ npm run build
 $ firebase login
 $ firebase use default


### PR DESCRIPTION
It's required to run npm install in the functions directory prior to being able to deploy