### PR TITLE
Add no-cache for service-worker

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -31,6 +31,12 @@
             "value": "1; mode=block"
           }
         ]
+      }, {
+        "source": "/service-worker.js",
+        "headers": [{
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }]
       }
     ],
     "rewrites": [


### PR DESCRIPTION
`service-worker.js` file should be under `/dist` folder after build.

as per create-react-app this should be the right fix - please make sure this is the right file name.