### PR TITLE
Feat/fix tasks order when many users enter

### DIFF
--- a/src/notification/reducer.js
+++ b/src/notification/reducer.js
@@ -1,5 +1,5 @@
 import { Record } from 'immutable';
-import { REMOVE_TASK_SUCCESS, UPDATE_TASK_ERROR } from 'src/tasks';
+import { REMOVE_TASK_SUCCESS, CREATE_TASK_ERROR, UPDATE_TASK_ERROR } from 'src/tasks';
 import { SIGN_IN_ERROR } from 'src/auth';
 import { DISMISS_NOTIFICATION, SHOW_ERROR, SHOW_SUCCESS } from './action-types';
 
@@ -19,6 +19,13 @@ export function notificationReducer(state = new NotificationState(), action) {
         display: true,
         type: 'success',
         message: 'המשימה נמחקה'
+      });
+
+    case CREATE_TASK_ERROR:
+      return state.merge({
+        display: true,
+        type: 'error',
+        message: action.payload.message ? action.payload.message : action.payload
       });
 
     case SIGN_IN_ERROR:

--- a/src/tasks/reducer.js
+++ b/src/tasks/reducer.js
@@ -42,8 +42,8 @@ export function tasksReducer(state = new TasksState(), {payload, type}) {
       return state.merge({
         deleted: null,
         created: payload,
-        list: state.list.unshift(payload),
-        filteredList: state.list.unshift(payload),
+        list: state.list.push(payload),
+        filteredList: state.list.push(payload),
         // Adds all the labels from the task into the labels pool
         labelsPool: state.labelsPool.union(Object.keys(payload.label || {})),
       });
@@ -58,13 +58,13 @@ export function tasksReducer(state = new TasksState(), {payload, type}) {
       });
 
     case LOAD_TASKS_SUCCESS:
-      const defaultTasks = new List(firebaseCollectionToList(payload.reverse()));
+      const defaultTasks = new List(firebaseCollectionToList(payload));
       return state.set('list', defaultTasks)
         .set('labelsPool',new Set(extractLabels((payload))))
         .set('filteredList', defaultTasks);
 
     case SET_FILTERED_TASKS:
-      return state.set('filteredList', new List(payload.reverse()));
+      return state.set('filteredList', new List(payload));
 
     case SET_SELECTED_FILTERS:
       return state.set('selectedFilters', payload);

--- a/src/tasks/task-list.js
+++ b/src/tasks/task-list.js
@@ -2,6 +2,7 @@ import { FirebaseList } from 'src/firebase';
 import * as taskActions from './actions';
 import { Task } from './task';
 
+// To set direction check actions->loadTasks method
 export const taskList = new FirebaseList({
   onAdd: taskActions.createTaskSuccess,
   onChange: taskActions.updateTaskSuccess,

--- a/src/views/molecules/search-bar/search-bar.js
+++ b/src/views/molecules/search-bar/search-bar.js
@@ -9,7 +9,7 @@ import './search-bar.css';
 class SearchBar extends Component {
   constructor(props){
     super(props)
-    this.debouncedOnQueryChange = debounce(this.props.onQueryChange, 50);
+    this.debouncedOnQueryChange = debounce(this.props.onQueryChange, 0);
   }
 
   render() {

--- a/src/views/pages/tasks/tasks-page.js
+++ b/src/views/pages/tasks/tasks-page.js
@@ -251,6 +251,8 @@ export class TasksPage extends Component {
 
   onNewTaskAdded(task) {
     // Remove this to keeps the user on the same page - allowing to create another new task
+    // Probably should only show on real success
+    this.props.showSuccess(i18n.t('task.created-successfully'));
 
     // Navigate to newly created task
     const project_url = this.props.match.params.projectUrl;
@@ -290,9 +292,6 @@ export class TasksPage extends Component {
       {title: task.title, creator, created: new Date(), description: task.description, requirements: task.requirements, type: task.type, label: task.label},
       this.props.auth,
       this.onNewTaskAdded);
-
-    // Probably should only show on real success
-    this.props.showSuccess(i18n.t('task.created-successfully'));
   }
 
   // Check if admin of that project


### PR DESCRIPTION
# Implements

- Moved the success message to after truly success adding tasks.
- Addied printing error if issues creating tasks.
- Made the list keep ordering asc-endry also when users are adding tasks

## Tests done
- Opened two parallel sessions
Saw that I see the old first tasks first. Created tasks in a different session and saw that it didn't changed the order of tasks.
- Opened the new task window - started inputting texts. Opened the other session - Added new tasks. Saw that it didn't interrupt the other window.